### PR TITLE
fix: revert how workflow steps are formatted

### DIFF
--- a/src/components/SimulationReports.vue
+++ b/src/components/SimulationReports.vue
@@ -231,9 +231,4 @@ onMounted(async () => {
 .v-overlay--active .v-overlay__scrim {
   display: none;
 }
-
-/* style the overlay container as required */
-.v-overlay--active {
-  backdrop-filter: blur(2px);
-}
 </style>

--- a/src/components/api.js
+++ b/src/components/api.js
@@ -1,7 +1,7 @@
 export const API_URL = "http://api.wsuv-hp-capstone.com"
 export const API_PORT = "80"
-//export const API_URL = "http://localhost"
-//export const API_PORT = "5040"
+// export const API_URL = "http://localhost"
+// export const API_PORT = "5040"
 
 
 export async function getCollection(coll){
@@ -65,13 +65,23 @@ export async function postWorkflow(Title, WorkflowSteps, Enabled, ParallelSteps,
 // prev step is the one before it in the array, and the next step
 // is the one after it, for compatibility with previous implementation
 export function formatSteps(steps){
-	let output = [];
+	const output = [];
 	for(let i = 0; i < steps.length; i++){
-    console.log(steps[i]);
+    let prev = null;
+    let next = null;
+
+    if (i > 0) {
+      prev = i-1;
+    }
+
+    if (i < steps.length-1) {
+      next = i+1;
+    }
+
 		output.push({
 			WorkflowStepID: steps[i],
-			Prev: [],
-			Next: []
+			Prev: prev === null ? [] : [prev],
+			Next: next === null ? [] : [next],
 		});
 	}
 	return output


### PR DESCRIPTION
there were a lot of conflicts when the compare simulation reports got merged and this got left out.

also, ditched the blur for now because I forgot to scope my CSS and it was popping up on literally every single overlay